### PR TITLE
Backported patch:

### DIFF
--- a/4.4.116/newPatches/0005-hv_netvsc-defer-queue-selection-to-VF.patch
+++ b/4.4.116/newPatches/0005-hv_netvsc-defer-queue-selection-to-VF.patch
@@ -1,0 +1,46 @@
+From 552dab6cc457e8d84533341516546702cf990fac Mon Sep 17 00:00:00 2001
+From: Your Name <you@example.com>
+Date: Sat, 11 Aug 2018 01:32:07 +0000
+Subject: [PATCH 5/5] hv_netvsc: defer queue selection to VF
+
+When VF is used
+ for accelerated networking it will likely have more queues (and different
+ policy) than the synthetic NIC. This patch defers the queue policy to the VF
+ so that all the queues can be used. This impacts workloads like local
+ generate UDP.
+
+Signed-off-by: Stephen Hemminger <sthemmin@microsoft.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/hyperv/netvsc_drv.c | 15 +++++++++++++--
+ 1 file changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/hyperv/netvsc_drv.c b/drivers/net/hyperv/netvsc_drv.c
+index 349cf8e..176cbfa 100644
+--- a/drivers/net/hyperv/netvsc_drv.c
++++ b/drivers/net/hyperv/netvsc_drv.c
+@@ -327,8 +327,19 @@ static u16 netvsc_select_queue(struct net_device *ndev, struct sk_buff *skb,
+ 	nvdev = hv_get_drvdata(dev);
+ 	vf_netdev = rcu_dereference(nvdev->vf_netdev);
+ 	if (vf_netdev) {
+-		txq = skb_rx_queue_recorded(skb) ? skb_get_rx_queue(skb) : 0;
+-		qdisc_skb_cb(skb)->slave_dev_queue_mapping = skb->queue_mapping;
++		const struct net_device_ops *vf_ops = vf_netdev->netdev_ops;
++
++		if (vf_ops->ndo_select_queue)
++			txq = vf_ops->ndo_select_queue(vf_netdev, skb,
++						       accel_priv, fallback);
++		else
++			txq = fallback(vf_netdev, skb);
++
++		/* Record the queue selected by VF so that it can be
++		 * used for common case where VF has more queues than
++		 * the synthetic device.
++		 */
++		qdisc_skb_cb(skb)->slave_dev_queue_mapping = txq;
+ 	} else {
+ 		txq = netvsc_pick_tx(ndev, skb);
+ 	}
+-- 
+2.1.4
+

--- a/4.4.116/newPatches/0006-Drivers-hv-vmbus-assign-CPU-to-channel-in-a-Hyper-Th.patch
+++ b/4.4.116/newPatches/0006-Drivers-hv-vmbus-assign-CPU-to-channel-in-a-Hyper-Th.patch
@@ -1,0 +1,72 @@
+From f7705a0af54c9524b86c95b55b0cd52b7608e758 Mon Sep 17 00:00:00 2001
+From: Your Name <you@example.com>
+Date: Mon, 13 Aug 2018 22:47:15 +0000
+Subject: [PATCH 6/6] Drivers: hv: vmbus: assign CPU to channel in a Hyper-Threading awareness way
+
+From: Simon Xiao <sixiao@microsoft.com>
+
+When assigning CPU to a vmbus channel,
+skip the CPU if its hyper-threading sibling has been assigned to a channel.
+---
+ drivers/hv/channel_mgmt.c | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git a/drivers/hv/channel_mgmt.c b/drivers/hv/channel_mgmt.c
+index a562318..c3d2760 100644
+--- a/drivers/hv/channel_mgmt.c
++++ b/drivers/hv/channel_mgmt.c
+@@ -28,6 +28,7 @@
+ #include <linux/list.h>
+ #include <linux/module.h>
+ #include <linux/completion.h>
++#include <linux/topology.h>
+ #include <linux/delay.h>
+ #include <linux/hyperv.h>
+ 
+@@ -407,6 +408,8 @@ static void init_vp_index(struct vmbus_channel *channel, const uuid_le *type_gui
+ 	int next_node;
+ 	struct cpumask available_mask;
+ 	struct cpumask *alloced_mask;
++	struct cpumask *cpu_sibling_mask;
++	struct cpumask *cpu_thread_tmp_mask;
+ 
+ 	for (i = IDE; i < MAX_PERF_CHN; i++) {
+ 		if (!memcmp(type_guid->b, hp_devs[i].guid,
+@@ -474,6 +477,14 @@ static void init_vp_index(struct vmbus_channel *channel, const uuid_le *type_gui
+ 			  cpumask_of_node(primary->numa_node)))
+ 		cpumask_clear(&primary->alloced_cpus_in_node);
+ 
++	cpu_thread_tmp_mask = kzalloc(cpumask_size(), GFP_KERNEL);
++	if (!cpu_thread_tmp_mask) {
++		channel->numa_node = 0;
++		channel->target_cpu = 0;
++		channel->target_vp = hv_context.vp_index[0];
++		return;
++	}
++
+ 	while (true) {
+ 		cur_cpu = cpumask_next(cur_cpu, &available_mask);
+ 		if (cur_cpu >= nr_cpu_ids) {
+@@ -483,6 +494,11 @@ static void init_vp_index(struct vmbus_channel *channel, const uuid_le *type_gui
+ 			continue;
+ 		}
+ 
++		cpu_sibling_mask = topology_sibling_cpumask(cur_cpu);
++		cpumask_and(cpu_thread_tmp_mask, cpu_sibling_mask, &available_mask);
++		if (!cpumask_equal(cpu_thread_tmp_mask, cpu_sibling_mask))
++			continue;
++
+ 		/*
+ 		 * NOTE: in the case of sub-channel, we clear the sub-channel
+ 		 * related bit(s) in primary->alloced_cpus_in_node in
+@@ -501,6 +517,7 @@ static void init_vp_index(struct vmbus_channel *channel, const uuid_le *type_gui
+ 
+ 	channel->target_cpu = cur_cpu;
+ 	channel->target_vp = hv_context.vp_index[cur_cpu];
++	kfree(cpu_thread_tmp_mask);
+ }
+ 
+ static void vmbus_wait_for_unload(void)
+-- 
+2.1.4
+


### PR DESCRIPTION
https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?id=b3bf5666a51068ad5ddd89a76ed877101ef3bc16
hv_netvsc: defer queue selection to VF
When VF is used for accelerated networking it will likely have
more queues (and different policy) than the synthetic NIC.
This patch defers the queue policy to the VF so that all the
queues can be used. This impacts workloads like local generate UDP.

Signed-off-by: Stephen Hemminger <sthemmin@microsoft.com>
Signed-off-by: David S. Miller <davem@davemloft.net>