### PR TITLE
Correct the format of patch 5 and 10

### DIFF
--- a/4.4.116/0005-hv_netvsc-defer-queue-selection-to-VF.patch
+++ b/4.4.116/0005-hv_netvsc-defer-queue-selection-to-VF.patch
@@ -1,69 +1,45 @@
-From cc061f57e712e8fa192593b56b559feb5db9c902 Mon Sep 17 00:00:00 2001
-From: Haiyang Zhang <haiyangz@microsoft.com>
-Date: Sat, 11 Aug 2018 01:50:05 +0000
-Subject: [PATCH 1/3] hv_netvsc: defer queue selection to VF
+From 552dab6cc457e8d84533341516546702cf990fac Mon Sep 17 00:00:00 2001
+From: Stephen Hemminger <sthemmin@microsoft.com>
+Date: Sat, 11 Aug 2018 01:32:07 +0000
+Subject: [PATCH] hv_netvsc: defer queue selection to VF
+When VF is used
+ for accelerated networking it will likely have more queues (and different
+ policy) than the synthetic NIC. This patch defers the queue policy to the VF
+ so that all the queues can be used. This impacts workloads like local
+ generate UDP.
 
-Backported by Haiyang Zhang from:
-
-hv_netvsc: defer queue selection to VF
-https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?id=b3bf5666a51068ad5ddd89a76ed877101ef3bc16
+Signed-off-by: Stephen Hemminger <sthemmin@microsoft.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
 ---
- ...v_netvsc-defer-queue-selection-to-VF.patch | 46 +++++++++++++++++++
- 1 file changed, 46 insertions(+)
- create mode 100644 4.4.116/newPatches/0005-hv_netvsc-defer-queue-selection-to-VF.patch
+ drivers/net/hyperv/netvsc_drv.c | 15 +++++++++++++--
+ 1 file changed, 13 insertions(+), 2 deletions(-)
 
-diff --git a/4.4.116/newPatches/0005-hv_netvsc-defer-queue-selection-to-VF.patch b/4.4.116/newPatches/0005-hv_netvsc-defer-queue-selection-to-VF.patch
-new file mode 100644
-index 000000000000..1292fa784dd3
---- /dev/null
-+++ b/4.4.116/newPatches/0005-hv_netvsc-defer-queue-selection-to-VF.patch
-@@ -0,0 +1,46 @@
-+From 552dab6cc457e8d84533341516546702cf990fac Mon Sep 17 00:00:00 2001
-+From: Your Name <you@example.com>
-+Date: Sat, 11 Aug 2018 01:32:07 +0000
-+Subject: [PATCH 5/5] hv_netvsc: defer queue selection to VF
+diff --git a/drivers/net/hyperv/netvsc_drv.c b/drivers/net/hyperv/netvsc_drv.c
+index 349cf8e..176cbfa 100644
+--- a/drivers/net/hyperv/netvsc_drv.c
++++ b/drivers/net/hyperv/netvsc_drv.c
+@@ -327,8 +327,19 @@ static u16 netvsc_select_queue(struct net_device *ndev, struct sk_buff *skb,
+ 	nvdev = hv_get_drvdata(dev);
+ 	vf_netdev = rcu_dereference(nvdev->vf_netdev);
+ 	if (vf_netdev) {
+-		txq = skb_rx_queue_recorded(skb) ? skb_get_rx_queue(skb) : 0;
+-		qdisc_skb_cb(skb)->slave_dev_queue_mapping = skb->queue_mapping;
++		const struct net_device_ops *vf_ops = vf_netdev->netdev_ops;
 +
-+When VF is used
-+ for accelerated networking it will likely have more queues (and different
-+ policy) than the synthetic NIC. This patch defers the queue policy to the VF
-+ so that all the queues can be used. This impacts workloads like local
-+ generate UDP.
++		if (vf_ops->ndo_select_queue)
++			txq = vf_ops->ndo_select_queue(vf_netdev, skb,
++						       accel_priv, fallback);
++		else
++			txq = fallback(vf_netdev, skb);
 +
-+Signed-off-by: Stephen Hemminger <sthemmin@microsoft.com>
-+Signed-off-by: David S. Miller <davem@davemloft.net>
-+---
-+ drivers/net/hyperv/netvsc_drv.c | 15 +++++++++++++--
-+ 1 file changed, 13 insertions(+), 2 deletions(-)
-+
-+diff --git a/drivers/net/hyperv/netvsc_drv.c b/drivers/net/hyperv/netvsc_drv.c
-+index 349cf8e..176cbfa 100644
-+--- a/drivers/net/hyperv/netvsc_drv.c
-++++ b/drivers/net/hyperv/netvsc_drv.c
-+@@ -327,8 +327,19 @@ static u16 netvsc_select_queue(struct net_device *ndev, struct sk_buff *skb,
-+ 	nvdev = hv_get_drvdata(dev);
-+ 	vf_netdev = rcu_dereference(nvdev->vf_netdev);
-+ 	if (vf_netdev) {
-+-		txq = skb_rx_queue_recorded(skb) ? skb_get_rx_queue(skb) : 0;
-+-		qdisc_skb_cb(skb)->slave_dev_queue_mapping = skb->queue_mapping;
-++		const struct net_device_ops *vf_ops = vf_netdev->netdev_ops;
-++
-++		if (vf_ops->ndo_select_queue)
-++			txq = vf_ops->ndo_select_queue(vf_netdev, skb,
-++						       accel_priv, fallback);
-++		else
-++			txq = fallback(vf_netdev, skb);
-++
-++		/* Record the queue selected by VF so that it can be
-++		 * used for common case where VF has more queues than
-++		 * the synthetic device.
-++		 */
-++		qdisc_skb_cb(skb)->slave_dev_queue_mapping = txq;
-+ 	} else {
-+ 		txq = netvsc_pick_tx(ndev, skb);
-+ 	}
-+-- 
-+2.1.4
-+
++		/* Record the queue selected by VF so that it can be
++		 * used for common case where VF has more queues than
++		 * the synthetic device.
++		 */
++		qdisc_skb_cb(skb)->slave_dev_queue_mapping = txq;
+ 	} else {
+ 		txq = netvsc_pick_tx(ndev, skb);
+ 	}
 -- 
-2.17.1
+2.1.4
 

--- a/4.4.116/0010-hack-l3-cache-fix-for-intel-vcpu-in-hyperv.pacth
+++ b/4.4.116/0010-hack-l3-cache-fix-for-intel-vcpu-in-hyperv.pacth
@@ -1,8 +1,11 @@
-commit 39be01ade9d26362d913f918543e8aef8784d691
-Author: root <root@haiyangz-toutiao-w-1.dugwoapfq1juxjhvgamii5uyvb.xx.internal.cloudapp.net>
-Date:   Thu Aug 23 21:41:12 2018 +0000
+From 14be599f4adb53689b5e4c00ec57e4f10f4a12d6 Mon Sep 17 00:00:00 2001
+From: Michael Kelley <Michael.H.Kelley@microsoft.com>
+Date: Fri, 24 Aug 2018 00:09:57 +0000
+Subject: [PATCH] HACK: force the L3 cache group for Intel vCPUs in HyperV
 
-    HACK: force the L3 cache group for Intel vCPUs in HyperV
+---
+ arch/x86/kernel/cpu/intel_cacheinfo.c | 2 ++
+ 1 file changed, 2 insertions(+)
 
 diff --git a/arch/x86/kernel/cpu/intel_cacheinfo.c b/arch/x86/kernel/cpu/intel_cacheinfo.c
 index b4ca91c..2ab3e49 100644
@@ -17,3 +20,6 @@ index b4ca91c..2ab3e49 100644
  	this_leaf->eax = eax;
  	this_leaf->ebx = ebx;
  	this_leaf->ecx = ecx;
+-- 
+2.1.4
+


### PR DESCRIPTION
0005-hv_netvsc-defer-queue-selection-to-VF.patch
0010-hack-l3-cache-fix-for-intel-vcpu-in-hyperv.pacth